### PR TITLE
Export custom feed importer

### DIFF
--- a/planet_elm/modules/custom/planet_elm_general/planet_elm_general.features.inc
+++ b/planet_elm/modules/custom/planet_elm_general/planet_elm_general.features.inc
@@ -8,6 +8,9 @@
  * Implements hook_ctools_plugin_api().
  */
 function planet_elm_general_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "feeds" && $api == "feeds_importer_default") {
+    return array("version" => "1");
+  }
   if ($module == "page_manager" && $api == "pages_default") {
     return array("version" => "1");
   }

--- a/planet_elm/modules/custom/planet_elm_general/planet_elm_general.feeds_importer_default.inc
+++ b/planet_elm/modules/custom/planet_elm_general/planet_elm_general.feeds_importer_default.inc
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @file
+ * planet_elm_general.feeds_importer_default.inc
+ */
+
+/**
+ * Implements hook_feeds_importer_default().
+ */
+function planet_elm_general_feeds_importer_default() {
+  $export = array();
+
+  $feeds_importer = new stdClass();
+  $feeds_importer->disabled = FALSE; /* Edit this to true to make a default feeds_importer disabled initially */
+  $feeds_importer->api_version = 1;
+  $feeds_importer->id = 'elm';
+  $feeds_importer->config = array(
+    'name' => 'Elm',
+    'description' => 'Import RSS or Atom feeds, create nodes from feed items.',
+    'fetcher' => array(
+      'plugin_key' => 'FeedsHTTPFetcher',
+      'config' => array(
+        'auto_detect_feeds' => 1,
+        'use_pubsubhubbub' => 0,
+        'designated_hub' => '',
+        'request_timeout' => NULL,
+        'auto_scheme' => 'http',
+        'accept_invalid_cert' => FALSE,
+      ),
+    ),
+    'parser' => array(
+      'plugin_key' => 'FeedsSyndicationParser',
+      'config' => array(),
+    ),
+    'processor' => array(
+      'plugin_key' => 'FeedsNodeProcessor',
+      'config' => array(
+        'bundle' => 'feed_item',
+        'update_existing' => '0',
+        'expire' => '-1',
+        'mappings' => array(
+          0 => array(
+            'source' => 'title',
+            'target' => 'title',
+            'unique' => FALSE,
+          ),
+          1 => array(
+            'source' => 'timestamp',
+            'target' => 'created',
+            'unique' => FALSE,
+          ),
+          2 => array(
+            'source' => 'url',
+            'target' => 'url',
+            'unique' => 1,
+          ),
+          3 => array(
+            'source' => 'guid',
+            'target' => 'guid',
+            'unique' => 1,
+          ),
+          4 => array(
+            'source' => 'description',
+            'target' => 'field_feed_item_description',
+            'unique' => FALSE,
+          ),
+        ),
+        'input_format' => 'filtered_html',
+        'author' => 0,
+        'authorize' => 0,
+        'update_non_existent' => 'skip',
+        'skip_hash_check' => 0,
+      ),
+    ),
+    'content_type' => 'feed',
+    'update' => 0,
+    'import_period' => '1800',
+    'expire_period' => 3600,
+    'import_on_create' => 1,
+    'process_in_background' => 0,
+  );
+  $export['elm'] = $feeds_importer;
+
+  return $export;
+}

--- a/planet_elm/modules/custom/planet_elm_general/planet_elm_general.info
+++ b/planet_elm/modules/custom/planet_elm_general/planet_elm_general.info
@@ -1,12 +1,15 @@
 name = Planet Elm General
 core = 7.x
 package = Elm
+dependencies[] = feeds
 dependencies[] = page_manager
 dependencies[] = views
 dependencies[] = views_content
+features[ctools][] = feeds:feeds_importer_default:1
 features[ctools][] = page_manager:pages_default:1
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
+features[feeds_importer][] = elm
 features[page_manager_pages][] = rss_view
 features[views_view][] = feed_items
 features[views_view][] = feeds


### PR DESCRIPTION
As we have overriden it by unchecking the "Authorize" in `admin/structure/feeds/elm/settings/FeedsNodeProcessor`

<img width="692" alt="elm___planetelm" src="https://cloud.githubusercontent.com/assets/125707/11043578/11c89ff6-8726-11e5-9826-e783ea478683.png">
