### PR TITLE
fix wide images

### DIFF
--- a/planet_elm/themes/custom/bootstrap_subtheme/css/style.css
+++ b/planet_elm/themes/custom/bootstrap_subtheme/css/style.css
@@ -36,6 +36,10 @@ a:hover {
   margin-bottom: 6px;
 }
 
+.field-content img {
+    max-width: 100%;
+    margin-bottom: 10px;
+}
 
 /* guide */
 


### PR DESCRIPTION
When coming in from Medium and other sources with <img> elements in the RSS, the theme displays the images at full width. This limits them to the maximum width of their container and adds a 10px bottom margin to be consistent with the title.

Fixes #41 